### PR TITLE
Config feature [WIP]

### DIFF
--- a/include/poser/core.h
+++ b/include/poser/core.h
@@ -3,6 +3,7 @@
 
 #include <poser/core/certinfo.h>
 #include <poser/core/client.h>
+#include <poser/core/config.h>
 #include <poser/core/connection.h>
 #include <poser/core/daemon.h>
 #include <poser/core/event.h>

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -66,31 +66,32 @@ DECLEXPORT void
 PSC_ConfigSection_destroy(PSC_ConfigSection *self);
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createString(const char *name, const char *defval)
+PSC_ConfigElement_createString(const char *name, const char *defval,
+	int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createInteger(const char *name, long defval)
+PSC_ConfigElement_createInteger(const char *name, long defval, int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createFloat(const char *name, double defval)
+PSC_ConfigElement_createFloat(const char *name, double defval, int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createBool(const char *name, int defval)
+PSC_ConfigElement_createBool(const char *name)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createSection(PSC_ConfigSection *section)
+PSC_ConfigElement_createSection(PSC_ConfigSection *section, int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createList(PSC_ConfigElement *element)
+PSC_ConfigElement_createList(PSC_ConfigElement *element, int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
-PSC_ConfigElement_createSectionList(PSC_ConfigSection *section)
+PSC_ConfigElement_createSectionList(PSC_ConfigSection *section, int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT void

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -198,7 +198,7 @@ PSC_ConfigParser_sampleFile(const PSC_ConfigParser *self, FILE *out)
 DECLEXPORT void
 PSC_ConfigParser_destroy(PSC_ConfigParser *self);
 
-DECLEXPORT void *
+DECLEXPORT const void *
 PSC_Config_get(const PSC_Config *self, const char *name)
     CMETHOD ATTR_NONNULL((2));
 

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -220,7 +220,8 @@ PSC_ConfigParser_argsAutoUsage(PSC_ConfigParser *self)
     CMETHOD;
 
 DECLEXPORT void
-PSC_ConfigParser_addFile(PSC_ConfigParser *self, const char *filename)
+PSC_ConfigParser_addFile(PSC_ConfigParser *self, const char *filename,
+	int required)
     CMETHOD ATTR_NONNULL((2));
 
 DECLEXPORT void

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -158,6 +158,10 @@ DECLEXPORT double
 PSC_ConfigParserCtx_float(const PSC_ConfigParserCtx *self)
     CMETHOD;
 
+DECLEXPORT int
+PSC_ConfigParserCtx_succeeded(const PSC_ConfigParserCtx *self)
+    CMETHOD;
+
 DECLEXPORT void
 PSC_ConfigParserCtx_setString(PSC_ConfigParserCtx *self, const char *val)
     CMETHOD;
@@ -171,8 +175,27 @@ PSC_ConfigParserCtx_setFloat(PSC_ConfigParserCtx *self, double val)
     CMETHOD;
 
 DECLEXPORT void
-PSC_ConfigParserCtx_fail(PSC_ConfigParserCtx *self, const char *error)
+PSC_ConfigParserCtx_setStringFor(PSC_ConfigParserCtx *self,
+	const char *name, const char *val)
+    CMETHOD ATTR_NONNULL((2)) ATTR_NONNULL((3));
+
+DECLEXPORT void
+PSC_ConfigParserCtx_setIntegerFor(PSC_ConfigParserCtx *self,
+	const char *name, long val)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT void
+PSC_ConfigParserCtx_setFloatFor(PSC_ConfigParserCtx *self,
+	const char *name, double val)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT void
+PSC_ConfigParserCtx_succeed(PSC_ConfigParserCtx *self)
     CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParserCtx_fail(PSC_ConfigParserCtx *self, const char *errfmt, ...)
+    CMETHOD ATTR_NONNULL((2)) ATTR_FORMAT((printf, 2, 3));
 
 DECLEXPORT PSC_ConfigParser *
 PSC_ConfigParser_create(const PSC_ConfigSection *root)

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -33,6 +33,8 @@ C_CLASS_DECL(PSC_ConfigParser);
  */
 C_CLASS_DECL(PSC_Config);
 
+C_CLASS_DECL(PSC_List);
+
 /** Callback for custom parsing or validating a single element.
  * @param ctx a context for parsing/validating
  */
@@ -172,6 +174,10 @@ PSC_ConfigParser_addArgs(PSC_ConfigParser *self, const char *defname,
     CMETHOD;
 
 DECLEXPORT void
+PSC_ConfigParser_argsAutoUsage(PSC_ConfigParser *self)
+    CMETHOD;
+
+DECLEXPORT void
 PSC_ConfigParser_addFile(PSC_ConfigParser *self, const char *filename)
     CMETHOD ATTR_NONNULL((2));
 
@@ -180,8 +186,12 @@ PSC_ConfigParser_autoPage(PSC_ConfigParser *self)
     CMETHOD;
 
 DECLEXPORT int
-PSC_ConfigParser_parse(const PSC_ConfigParser *self, PSC_Config **config)
+PSC_ConfigParser_parse(PSC_ConfigParser *self, PSC_Config **config)
     CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT const PSC_List *
+PSC_ConfigParser_errors(const PSC_ConfigParser *self)
+    CMETHOD ATTR_RETNONNULL;
 
 DECLEXPORT int
 PSC_ConfigParser_usage(const PSC_ConfigParser *self, FILE *out)

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -1,0 +1,180 @@
+#ifndef POSER_CORE_CONFIG_H
+#define POSER_CORE_CONFIG_H
+
+#include <poser/decl.h>
+#include <stdio.h>
+
+/** declarations for the classes handling configuration
+ * @file
+ */
+
+/** A description of a configuration section.
+ * @class PSC_ConfigSection config.h <poser/core/config.h>
+ */
+C_CLASS_DECL(PSC_ConfigSection);
+
+/** A description of a configuration element.
+ * @class PSC_ConfigElement config.h <poser/core/config.h>
+ */
+C_CLASS_DECL(PSC_ConfigElement);
+
+/** Context for custom parsing or validating a single element.
+ * @class PSC_ConfigParserCtx config.h <poser/core/config.h>
+ */
+C_CLASS_DECL(PSC_ConfigParserCtx);
+
+/** Generic parser for configurations.
+ * @class PSC_ConfigParser config.h <poser/core/config.h>
+ */
+C_CLASS_DECL(PSC_ConfigParser);
+
+/** Parsed configuration.
+ * @class PSC_Config config.h <poser/core/config.h>
+ */
+C_CLASS_DECL(PSC_Config);
+
+/** Callback for custom parsing or validating a single element.
+ * @param ctx a context for parsing/validating
+ */
+typedef void (*PSC_ConfigElementCallback)(PSC_ConfigParserCtx *ctx);
+
+/** PSC_ConfigSection default constructor.
+ * Creates a new PSC_ConfigSection
+ * @memberof PSC_ConfigSection
+ * @param name the name of the section, NULL for the root section
+ * @returns a newly created PSC_ConfigSection
+ */
+DECLEXPORT PSC_ConfigSection *
+PSC_ConfigSection_create(const char *name)
+    ATTR_RETNONNULL;
+
+/** Add an element to the config section.
+ * @memberof PSC_ConfigSection
+ * @param self the PSC_ConfigSection
+ * @param element the element to add
+ */
+DECLEXPORT void
+PSC_ConfigSection_add(PSC_ConfigSection *self, PSC_ConfigElement *element)
+    CMETHOD ATTR_NONNULL((2));
+
+/** PSC_ConfigSection destructor.
+ * This also destroys any added members.
+ * @memberof PSC_ConfigSection
+ * @param self the PSC_ConfigSection
+ */
+DECLEXPORT void
+PSC_ConfigSection_destroy(PSC_ConfigSection *self);
+
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createString(const char *name, const char *defval)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createInteger(const char *name, long defval)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createFloat(const char *name, double defval)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createSection(PSC_ConfigSection *section)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createList(PSC_ConfigElement *element)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createSectionList(PSC_ConfigSection *section)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT void
+PSC_ConfigElement_setFlag(PSC_ConfigElement *self, int flag)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigElement_describe(PSC_ConfigElement *self, const char *description)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigElement_parse(PSC_ConfigElement *self,
+	PSC_ConfigElementCallback parser)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigElement_validate(PSC_ConfigElement *self,
+	PSC_ConfigElementCallback validator)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigElement_destroy(PSC_ConfigElement *self);
+
+DECLEXPORT const char *
+PSC_ConfigParserCtx_string(const PSC_ConfigParserCtx *self)
+    CMETHOD ATTR_RETNONNULL;
+
+DECLEXPORT long
+PSC_ConfigParserCtx_integer(const PSC_ConfigParserCtx *self)
+    CMETHOD;
+
+DECLEXPORT double
+PSC_ConfigParserCtx_float(const PSC_ConfigParserCtx *self)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParserCtx_setString(PSC_ConfigParserCtx *self, const char *val)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParserCtx_setInteger(PSC_ConfigParserCtx *self, long val)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParserCtx_setFloat(PSC_ConfigParserCtx *self, double val)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParserCtx_fail(PSC_ConfigParserCtx *self, const char *error)
+    CMETHOD;
+
+DECLEXPORT PSC_ConfigParser *
+PSC_ConfigParser_create(const PSC_ConfigSection *root)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT void
+PSC_ConfigParser_addArgs(PSC_ConfigParser *self, const char *defname,
+	int argc, char **argv)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParser_addFile(PSC_ConfigParser *self, const char *filename)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT PSC_Config *
+PSC_ConfigParser_parse(const PSC_ConfigParser *self)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParser_usage(const PSC_ConfigParser *self, FILE *out)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParser_help(const PSC_ConfigParser *self, FILE *out)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParser_sampleFile(const PSC_ConfigParser *self, FILE *out)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigParser_destroy(PSC_ConfigParser *self);
+
+DECLEXPORT void *
+PSC_Config_get(const PSC_Config *self, const char *name)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT void
+PSC_Config_destroy(PSC_Config *self);
+
+#endif

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -38,6 +38,11 @@ C_CLASS_DECL(PSC_Config);
  */
 typedef void (*PSC_ConfigElementCallback)(PSC_ConfigParserCtx *ctx);
 
+/** Callback for a custom immediate action when a config element is found.
+ * @param data some custom data
+ */
+typedef void (*PSC_ConfigAction)(void *data);
+
 /** PSC_ConfigSection default constructor.
  * Creates a new PSC_ConfigSection
  * @memberof PSC_ConfigSection
@@ -100,6 +105,19 @@ PSC_ConfigElement_argInfo(PSC_ConfigElement *self, int flag,
     CMETHOD;
 
 DECLEXPORT void
+PSC_ConfigElement_argOnly(PSC_ConfigElement *self)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigElement_argAction(PSC_ConfigElement *self,
+	PSC_ConfigAction action, void *actionData)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT void
+PSC_ConfigElement_fileOnly(PSC_ConfigElement *self)
+    CMETHOD;
+
+DECLEXPORT void
 PSC_ConfigElement_describe(PSC_ConfigElement *self, const char *description)
     CMETHOD;
 
@@ -157,9 +175,13 @@ DECLEXPORT void
 PSC_ConfigParser_addFile(PSC_ConfigParser *self, const char *filename)
     CMETHOD ATTR_NONNULL((2));
 
-DECLEXPORT PSC_Config *
-PSC_ConfigParser_parse(const PSC_ConfigParser *self)
+DECLEXPORT void
+PSC_ConfigParser_autoPage(PSC_ConfigParser *self)
     CMETHOD;
+
+DECLEXPORT int
+PSC_ConfigParser_parse(const PSC_ConfigParser *self, PSC_Config **config)
+    CMETHOD ATTR_NONNULL((2));
 
 DECLEXPORT int
 PSC_ConfigParser_usage(const PSC_ConfigParser *self, FILE *out)

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -64,6 +64,16 @@ DECLEXPORT void
 PSC_ConfigSection_add(PSC_ConfigSection *self, PSC_ConfigElement *element)
     CMETHOD ATTR_NONNULL((2));
 
+DECLEXPORT void
+PSC_ConfigSection_addHelpArg(PSC_ConfigSection *self,
+	const char *description, const char *name, char flag)
+    CMETHOD;
+
+DECLEXPORT void
+PSC_ConfigSection_addVersionArg(PSC_ConfigSection *self, const char *version,
+	const char *description, const char *name, char flag)
+    CMETHOD ATTR_NONNULL((2));
+
 /** PSC_ConfigSection destructor.
  * This also destroys any added members.
  * @memberof PSC_ConfigSection
@@ -101,6 +111,11 @@ DECLEXPORT PSC_ConfigElement *
 PSC_ConfigElement_createSectionList(PSC_ConfigSection *section, int required)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
+DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createAction(const char *name,
+	PSC_ConfigAction action, void *actionData)
+    ATTR_RETNONNULL ATTR_NONNULL((1)) ATTR_NONNULL((2));
+
 DECLEXPORT void
 PSC_ConfigElement_argInfo(PSC_ConfigElement *self, int flag,
 	const char *argname)
@@ -109,11 +124,6 @@ PSC_ConfigElement_argInfo(PSC_ConfigElement *self, int flag,
 DECLEXPORT void
 PSC_ConfigElement_argOnly(PSC_ConfigElement *self)
     CMETHOD;
-
-DECLEXPORT void
-PSC_ConfigElement_argAction(PSC_ConfigElement *self,
-	PSC_ConfigAction action, void *actionData)
-    CMETHOD ATTR_NONNULL((2));
 
 DECLEXPORT void
 PSC_ConfigElement_fileOnly(PSC_ConfigElement *self)

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -78,6 +78,10 @@ PSC_ConfigElement_createFloat(const char *name, double defval)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT PSC_ConfigElement *
+PSC_ConfigElement_createBool(const char *name, int defval)
+    ATTR_RETNONNULL ATTR_NONNULL((1));
+
+DECLEXPORT PSC_ConfigElement *
 PSC_ConfigElement_createSection(PSC_ConfigSection *section)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
@@ -90,7 +94,8 @@ PSC_ConfigElement_createSectionList(PSC_ConfigSection *section)
     ATTR_RETNONNULL ATTR_NONNULL((1));
 
 DECLEXPORT void
-PSC_ConfigElement_setFlag(PSC_ConfigElement *self, int flag)
+PSC_ConfigElement_argInfo(PSC_ConfigElement *self, int flag,
+	const char *argname)
     CMETHOD;
 
 DECLEXPORT void
@@ -155,15 +160,15 @@ DECLEXPORT PSC_Config *
 PSC_ConfigParser_parse(const PSC_ConfigParser *self)
     CMETHOD;
 
-DECLEXPORT void
+DECLEXPORT int
 PSC_ConfigParser_usage(const PSC_ConfigParser *self, FILE *out)
     CMETHOD;
 
-DECLEXPORT void
+DECLEXPORT int
 PSC_ConfigParser_help(const PSC_ConfigParser *self, FILE *out)
     CMETHOD;
 
-DECLEXPORT void
+DECLEXPORT int
 PSC_ConfigParser_sampleFile(const PSC_ConfigParser *self, FILE *out)
     CMETHOD;
 

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -204,7 +204,7 @@ PSC_ConfigParser_errors(const PSC_ConfigParser *self)
     CMETHOD ATTR_RETNONNULL;
 
 DECLEXPORT int
-PSC_ConfigParser_usage(const PSC_ConfigParser *self, FILE *out)
+PSC_ConfigParser_usage(const PSC_ConfigParser *self, FILE *out, int witherrors)
     CMETHOD;
 
 DECLEXPORT int
@@ -220,6 +220,18 @@ PSC_ConfigParser_destroy(PSC_ConfigParser *self);
 
 DECLEXPORT const void *
 PSC_Config_get(const PSC_Config *self, const char *name)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT const char *
+PSC_Config_getString(const PSC_Config *self, const char *name)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT long
+PSC_Config_getInteger(const PSC_Config *self, const char *name)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT double
+PSC_Config_getFloat(const PSC_Config *self, const char *name)
     CMETHOD ATTR_NONNULL((2));
 
 DECLEXPORT void

--- a/include/poser/core/config.h
+++ b/include/poser/core/config.h
@@ -65,6 +65,11 @@ PSC_ConfigSection_add(PSC_ConfigSection *self, PSC_ConfigElement *element)
     CMETHOD ATTR_NONNULL((2));
 
 DECLEXPORT void
+PSC_ConfigSection_validate(PSC_ConfigSection *self,
+	PSC_ConfigElementCallback validator)
+    CMETHOD ATTR_NONNULL((2));
+
+DECLEXPORT void
 PSC_ConfigSection_addHelpArg(PSC_ConfigSection *self,
 	const char *description, const char *name, char flag)
     CMETHOD;
@@ -156,6 +161,10 @@ PSC_ConfigParserCtx_integer(const PSC_ConfigParserCtx *self)
 
 DECLEXPORT double
 PSC_ConfigParserCtx_float(const PSC_ConfigParserCtx *self)
+    CMETHOD;
+
+DECLEXPORT const PSC_Config *
+PSC_ConfigParserCtx_section(const PSC_ConfigParserCtx *self)
     CMETHOD;
 
 DECLEXPORT int

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -19,7 +19,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <termios.h>
-#include <threads.h>
 #include <unistd.h>
 
 #define DEFLINELEN 80
@@ -37,7 +36,7 @@ static volatile sig_atomic_t pagerexited;
 
 static int boolval = 1;
 
-static thread_local PSC_ConfigParser *activeParser;
+static PSC_ConfigParser *activeParser;
 
 struct PSC_ConfigSection
 {

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -68,7 +68,11 @@ typedef enum ParserType
 struct PSC_ConfigElement
 {
     PSC_ConfigElementCallback parser;
-    PSC_ConfigElementCallback validator;
+    union
+    {
+	PSC_ConfigElementCallback validator;
+	PSC_ConfigAction action;
+    };
     char *name;
     char *argname;
     char *description;
@@ -79,11 +83,7 @@ struct PSC_ConfigElement
 	double defFloat;
 	PSC_ConfigSection *section;
 	PSC_ConfigElement *element;
-	struct
-	{
-	    PSC_ConfigAction action;
-	    void *actionData;
-	};
+	void *actionData;
     };
     ElemType type;
     ParserType pt;

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -1,0 +1,275 @@
+#include "util.h"
+
+#include <poser/core/config.h>
+#include <poser/core/hashtable.h>
+#include <poser/core/list.h>
+#include <poser/core/service.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct PSC_ConfigSection
+{
+    char *name;
+    PSC_List *elements;
+};
+
+typedef enum ElemType
+{
+    ET_STRING,
+    ET_INTEGER,
+    ET_FLOAT,
+    ET_SECTION,
+    ET_LIST,
+    ET_SECTIONLIST
+} ElemType;
+
+struct PSC_ConfigElement
+{
+    PSC_ConfigElementCallback parser;
+    PSC_ConfigElementCallback validator;
+    char *name;
+    char *description;
+    union
+    {
+	char *defString;
+	long defInteger;
+	double defFloat;
+	PSC_ConfigSection *section;
+	PSC_ConfigElement *element;
+    };
+    ElemType type;
+    int flag;
+};
+
+struct PSC_ConfigParserCtx
+{
+    char *string;
+    char *error;
+    union
+    {
+	long integerVal;
+	double floatVal;
+    };
+    ElemType type;
+    int success;
+};
+
+struct PSC_ConfigParser
+{
+    PSC_ConfigSection *root;
+    PSC_List *parsers;
+};
+
+struct PSC_Config
+{
+    PSC_HashTable *values;
+};
+
+SOEXPORT PSC_ConfigSection *PSC_ConfigSection_create(const char *name)
+{
+    PSC_ConfigSection *self = PSC_malloc(sizeof *self);
+    self->name = PSC_copystr(name);
+    self->elements = PSC_List_create();
+    return self;
+}
+
+static void deleteElement(void *element)
+{
+    PSC_ConfigElement_destroy(element);
+}
+
+SOEXPORT void PSC_ConfigSection_add(PSC_ConfigSection *self,
+	PSC_ConfigElement *element)
+{
+    PSC_List_append(self->elements, element, deleteElement);
+}
+
+SOEXPORT void PSC_ConfigSection_destroy(PSC_ConfigSection *self)
+{
+    if (!self) return;
+    PSC_List_destroy(self->elements);
+    free(self->name);
+    free(self);
+}
+
+SOEXPORT PSC_ConfigElement *PSC_ConfigElement_createString(const char *name,
+	const char *defval)
+{
+    PSC_ConfigElement *self = PSC_malloc(sizeof *self);
+    memset(self, 0, sizeof *self);
+    self->name = PSC_copystr(name);
+    self->defString = PSC_copystr(defval);
+    self->type = ET_STRING;
+    return self;
+}
+
+SOEXPORT PSC_ConfigElement *PSC_ConfigElement_createInteger(const char *name,
+	long defval)
+{
+    PSC_ConfigElement *self = PSC_malloc(sizeof *self);
+    memset(self, 0, sizeof *self);
+    self->name = PSC_copystr(name);
+    self->defInteger = defval;
+    self->type = ET_INTEGER;
+    return self;
+}
+
+SOEXPORT PSC_ConfigElement *PSC_ConfigElement_createFloat(const char *name,
+	double defval)
+{
+    PSC_ConfigElement *self = PSC_malloc(sizeof *self);
+    memset(self, 0, sizeof *self);
+    self->name = PSC_copystr(name);
+    self->defFloat = defval;
+    self->type = ET_FLOAT;
+    return self;
+}
+
+SOEXPORT PSC_ConfigElement *PSC_ConfigElement_createSection(
+	PSC_ConfigSection *section)
+{
+    PSC_ConfigElement *self = PSC_malloc(sizeof *self);
+    memset(self, 0, sizeof *self);
+    self->section = section;
+    self->type = ET_SECTION;
+    return self;
+}
+
+SOEXPORT PSC_ConfigElement *PSC_ConfigElement_createList(
+	PSC_ConfigElement *element)
+{
+    PSC_ConfigElement *self = PSC_malloc(sizeof *self);
+    memset(self, 0, sizeof *self);
+    self->element = element;
+    self->type = ET_LIST;
+    return self;
+}
+
+SOEXPORT PSC_ConfigElement *PSC_ConfigElement_createSectionList(
+	PSC_ConfigSection *section)
+{
+    PSC_ConfigElement *self = PSC_malloc(sizeof *self);
+    memset(self, 0, sizeof *self);
+    self->section = section;
+    self->type = ET_SECTIONLIST;
+    return self;
+}
+
+SOEXPORT void PSC_ConfigElement_setFlag(PSC_ConfigElement *self, int flag)
+{
+    self->flag = flag;
+}
+
+SOEXPORT void PSC_ConfigElement_describe(PSC_ConfigElement *self,
+	const char *description)
+{
+    free(self->description);
+    self->description = PSC_copystr(description);
+}
+
+SOEXPORT void PSC_ConfigElement_parse(PSC_ConfigElement *self,
+	PSC_ConfigElementCallback parser)
+{
+    self->parser = parser;
+}
+
+SOEXPORT void PSC_ConfigElement_validate(PSC_ConfigElement *self,
+	PSC_ConfigElementCallback validator)
+{
+    self->validator = validator;
+}
+
+SOEXPORT void PSC_ConfigElement_destroy(PSC_ConfigElement *self)
+{
+    if (!self) return;
+    free(self->name);
+    free(self->description);
+    switch (self->type)
+    {
+	case ET_STRING:
+	    free(self->defString);
+	    break;
+	
+	case ET_SECTION:
+	case ET_SECTIONLIST:
+	    PSC_ConfigSection_destroy(self->section);
+	    break;
+
+	case ET_LIST:
+	    PSC_ConfigElement_destroy(self->element);
+	    break;
+	
+	default:
+	    ;
+    }
+    free(self);
+}
+
+SOEXPORT const char *PSC_ConfigParserCtx_string(
+	const PSC_ConfigParserCtx *self)
+{
+    return self->string;
+}
+
+SOEXPORT long PSC_ConfigParserCtx_integer(const PSC_ConfigParserCtx *self)
+{
+    if (self->type != ET_INTEGER)
+    {
+	PSC_Service_panic("Tried to get integer value from configuration "
+		"element that is not an integer");
+    }
+    return self->integerVal;
+}
+
+SOEXPORT double PSC_ConfigParserCtx_float(const PSC_ConfigParserCtx *self)
+{
+    if (self->type != ET_FLOAT)
+    {
+	PSC_Service_panic("Tried to get float value from configuration "
+		"element that is not a float");
+    }
+    return self->floatVal;
+}
+
+SOEXPORT void PSC_ConfigParserCtx_setString(PSC_ConfigParserCtx *self,
+	const char *val)
+{
+    if (self->type != ET_STRING)
+    {
+	PSC_Service_panic("Tried to set string value on configuration "
+		"element that is not a string");
+    }
+    free(self->string);
+    self->string = PSC_copystr(val);
+}
+
+SOEXPORT void PSC_ConfigParserCtx_setInteger(PSC_ConfigParserCtx *self,
+	long val)
+{
+    if (self->type != ET_INTEGER)
+    {
+	PSC_Service_panic("Tried to set integer value on configuration "
+		"element that is not an integer");
+    }
+    self->integerVal = val;
+}
+
+SOEXPORT void PSC_ConfigParserCtx_setFloat(PSC_ConfigParserCtx *self,
+	double val)
+{
+    if (self->type != ET_FLOAT)
+    {
+	PSC_Service_panic("Tried to set float value on configuration "
+		"element that is not a float");
+    }
+    self->floatVal = val;
+}
+
+SOEXPORT void PSC_ConfigParserCtx_fail(PSC_ConfigParserCtx *self,
+	const char *error)
+{
+    free(self->error);
+    self->error = PSC_copystr(error);
+    self->success = 0;
+}
+

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -207,7 +207,7 @@ SOEXPORT void PSC_ConfigSection_add(PSC_ConfigSection *self,
 static void helpargprint(void *data)
 {
     (void)data;
-    PSC_ConfigParser_help(activeParser, stderr);
+    PSC_ConfigParser_help(activeParser, stdout);
 }
 
 SOEXPORT void PSC_ConfigSection_addHelpArg(PSC_ConfigSection *self,
@@ -228,7 +228,7 @@ SOEXPORT void PSC_ConfigSection_addHelpArg(PSC_ConfigSection *self,
 static void versionargprint(void *data)
 {
     const char *version = data;
-    fprintf(stderr, "%s\n", version);
+    puts(version);
 }
 
 SOEXPORT void PSC_ConfigSection_addVersionArg(PSC_ConfigSection *self,

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -405,6 +405,7 @@ static void setoutputwidth(FILE *out)
 	    return;
 	}
     }
+#if defined(TIOCGWINSZ)
     struct winsize sz;
     if (ioctl(outfd, TIOCGWINSZ, &sz) >= 0)
     {
@@ -413,6 +414,16 @@ static void setoutputwidth(FILE *out)
 	else currlinelen = (size_t)sz.ws_col;
 	return;
     }
+#elif defined(TIOCGSIZE)
+    struct ttysize sz;
+    if (ioctl(outfd, TIOCGSIZE, &sz) >= 0)
+    {
+	if (sz.ts_cols < MINLINELEN) currlinelen = MINLINELEN;
+	else if (sz.ts_cols > MAXLINELEN) currlinelen = MAXLINELEN;
+	else currlinelen = (size_t)sz.ts_cols;
+	return;
+    }
+#endif
     currlinelen = DEFLINELEN;
 }
 

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -1801,7 +1801,28 @@ static int parseargssection(PSC_Config *cfg, const PSC_ConfigSection *sect,
 	}
 	if (e)
 	{
-	    if (e->type != ET_SECTION && e->type != ET_SECTIONLIST)
+	    if (e->type == ET_BOOL)
+	    {
+		if (item->key)
+		{
+		    if (!item->val[1])
+		    {
+			if (item->val[0] == '0') PSC_HashTable_delete(
+				cfg->values, namestr(e));
+			else if (item->val[0] == '1') PSC_HashTable_set(
+				cfg->values, namestr(e), &boolval, 0);
+			else rc = -1;
+		    }
+		    else rc = -1;
+		    if (rc < 0)
+		    {
+			addparsererror(errors, "subsection: invalid boolean "
+				"value `%s'", item->val);
+		    }
+		}
+		else PSC_HashTable_set(cfg->values, namestr(e), &boolval, 0);
+	    }
+	    else if (e->type != ET_SECTION && e->type != ET_SECTIONLIST)
 	    {
 		void *val = parseargsvalue(e, cfg, errors, item->val, 0);
 		if (!val) rc = -1;

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -519,6 +519,20 @@ done:
     return rc;
 }
 
+static const char *namestr(const PSC_ConfigElement *e)
+{
+    switch (e->type)
+    {
+	case ET_LIST:
+	    return e->element->name;
+	case ET_SECTION:
+	case ET_SECTIONLIST:
+	    return e->section->name;
+	default:
+	    return e->name;
+    }
+}
+
 static const char *argstr(const PSC_ConfigElement *e)
 {
     const char *result = e->argname;
@@ -733,7 +747,7 @@ static int subsectionhelp(const PSC_ConfigSection *sect, FILE *out)
 	    flags[nflags++] = e;
 	    if (e->required) ++nreqflags;
 	}
-	else if (e->name)
+	else if (namestr(e))
 	{
 	    if (e->required) reqposargs[nreqposargs++] = e;
 	    else optposargs[noptposargs++] = e;
@@ -840,7 +854,7 @@ static int subsectionhelp(const PSC_ConfigSection *sect, FILE *out)
 	    PSC_ConfigElement *e = flags[j];
 	    s = PSC_StringBuilder_create();
 	    if (e->flag > 0) PSC_StringBuilder_appendChar(s, e->flag);
-	    else PSC_StringBuilder_append(s, e->name);
+	    else PSC_StringBuilder_append(s, namestr(e));
 	    PSC_StringBuilder_appendChar(s, '=');
 	    if (e->type == ET_BOOL) PSC_StringBuilder_append(s, "[0|1]");
 	    else PSC_StringBuilder_append(s, argstr(e));
@@ -910,7 +924,7 @@ SOEXPORT int PSC_ConfigParser_help(const PSC_ConfigParser *self, FILE *out)
 	}
 	else if (e->flag == 0)
 	{
-	    if (e->name) longflags[nlongflags++] = e;
+	    if (namestr(e)) longflags[nlongflags++] = e;
 	}
 	else
 	{
@@ -937,14 +951,14 @@ SOEXPORT int PSC_ConfigParser_help(const PSC_ConfigParser *self, FILE *out)
 	    PSC_StringBuilder_appendChar(s, '\t');
 	    PSC_StringBuilder_append(s, argstr(e));
 	}
-	if (e->name)
+	if (namestr(e))
 	{
 	    PSC_StringBuilder_append(s, ", --");
 	    if (e->type == ET_BOOL)
 	    {
 		PSC_StringBuilder_append(s, "[no-]");
 	    }
-	    PSC_StringBuilder_append(s, e->name);
+	    PSC_StringBuilder_append(s, namestr(e));
 	    if (e->type != ET_BOOL)
 	    {
 		PSC_StringBuilder_appendChar(s, '=');
@@ -971,7 +985,7 @@ SOEXPORT int PSC_ConfigParser_help(const PSC_ConfigParser *self, FILE *out)
 	{
 	    PSC_StringBuilder_append(s, "[no-]");
 	}
-	PSC_StringBuilder_append(s, e->name);
+	PSC_StringBuilder_append(s, namestr(e));
 	if (e->type != ET_BOOL)
 	{
 	    PSC_StringBuilder_appendChar(s, '=');

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -728,7 +728,7 @@ static int printlines(FILE *out, PSC_List *lines, int autopage)
     int rc = -1;
     const char *pager = 0;
 
-    if (autopage && isatty(fileno(out))
+    if (autopage && out == stdout && isatty(fileno(out))
 	    && PSC_List_size(lines) + 2 >= currlines)
     {
 	pager = getenv("PAGER");
@@ -769,13 +769,6 @@ static int printlines(FILE *out, PSC_List *lines, int autopage)
 		    fcntl(errpfd[1], F_SETFD, FD_CLOEXEC);
 		    dup2(pfd[0], STDIN_FILENO);
 		    close(pfd[0]);
-		    int ttyfd = open("/dev/tty", O_WRONLY|O_NONBLOCK);
-		    if (ttyfd >= 0)
-		    {
-			dup2(ttyfd, STDOUT_FILENO);
-			dup2(ttyfd, STDERR_FILENO);
-			close(ttyfd);
-		    }
 		    PSC_List *pagercmd = PSC_List_fromString(pager, " ");
 		    if (pagercmd)
 		    {
@@ -824,6 +817,7 @@ static int printlines(FILE *out, PSC_List *lines, int autopage)
 			PSC_ListIterator_destroy(i);
 			fclose(pgout);
 		    }
+		    else pagerfailed = 1;
 		}
 		else pagerfailed = 1;
 		fclose(pgin);

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -1034,6 +1034,8 @@ static PSC_List *usagelines(const PSC_ConfigParser *self, FILE *out)
     const char *svname = getargsvname(getargparser(self));
     if (!svname) PSC_Service_panic(
 	    "Can't print usage without a configured args parser");
+    int indent = 11;
+    if (strlen(svname) < 8) indent = strlen(svname) + 8;
 
     size_t elemcount = PSC_List_size(self->root->elements);
     boolflags = PSC_malloc(elemcount);
@@ -1133,7 +1135,7 @@ static PSC_List *usagelines(const PSC_ConfigParser *self, FILE *out)
 
     setoutputdims(out);
     PSC_List *lines = PSC_List_create();
-    formatlines(lines, s, 0, 8, 0);
+    formatlines(lines, s, 0, indent, 0);
 
     for (int j = 0; j < nactflags; ++j)
     {
@@ -1150,7 +1152,7 @@ static PSC_List *usagelines(const PSC_ConfigParser *self, FILE *out)
 	    PSC_StringBuilder_append(s, " --");
 	    PSC_StringBuilder_append(s, namestr(e));
 	}
-	formatlines(lines, s, 7, 8, 0);
+	formatlines(lines, s, 7, indent, 0);
     }
 
     return lines;

--- a/src/lib/core/config.c
+++ b/src/lib/core/config.c
@@ -605,6 +605,13 @@ static int printlines(FILE *out, PSC_List *lines, int autopage)
 		    fcntl(errpfd[1], F_SETFD, FD_CLOEXEC);
 		    dup2(pfd[0], STDIN_FILENO);
 		    close(pfd[0]);
+		    int ttyfd = open("/dev/tty", O_WRONLY|O_NONBLOCK);
+		    if (ttyfd >= 0)
+		    {
+			dup2(ttyfd, STDOUT_FILENO);
+			dup2(ttyfd, STDERR_FILENO);
+			close(ttyfd);
+		    }
 		    PSC_List *pagercmd = PSC_List_fromString(pager, " ");
 		    if (pagercmd)
 		    {

--- a/src/lib/core/core.mk
+++ b/src/lib/core/core.mk
@@ -1,5 +1,6 @@
 posercore_MODULES:=		certinfo \
 				client \
+				config \
 				connection \
 				daemon \
 				event \
@@ -17,6 +18,7 @@ posercore_MODULES:=		certinfo \
 posercore_HEADERS_INSTALL:=	core \
 				core/certinfo \
 				core/client \
+				core/config \
 				core/connection \
 				core/daemon \
 				core/event \


### PR DESCRIPTION
This attempts to add generic configuration support to libposercore. It is work in progress, the open pull request just ensures the feature branch will be checked using CI builds.

Planned feature set:
* A parser for command-line arguments
  - Support for POSIX short flags and GNU long flags
  - Support for any arrangement of flag arguments (with/without whitespace, in a queue after collapsed short flags, ...)
  - Support for positional arguments
  - Support for one level of nesting (sub-sections) using a custom colon-delimited format
* A parser for configuration files
  - Support for a (very limited) subset of TOML
* Free stacking of parsers, later parsers will append (for lists) or replace earlier values
* Custom parser callbacks for single elements, custom validator callbacks for elements and sections
* Auto-generation of:
  - "Usage" messages
  - "Help" messages
  - A sample configuration file